### PR TITLE
Strip trailing whitespace on parameter text

### DIFF
--- a/irclib/parser.py
+++ b/irclib/parser.py
@@ -285,7 +285,7 @@ class ParamList(Parseable, tuple):
         has_trail = False
         while text:
             if text[0] == TRAIL_SENTINEL:
-                args.append(text[1:])
+                args.append(text[1:].rstrip())
                 has_trail = True
                 break
 


### PR DESCRIPTION
Not sure if I'm doing something wrong, but IRC capabilities seems to break for me - when servers ACK, the response has trailing whitespace:-

`yahk.services.irc: DEBUG    IRC/irc.vntx.net: :kornbluth.freenode.net CAP yahk ACK :sasl `

This change fixes this by stripping whitespace off the trailing text and it now works for me. Feel free to reject if I'm doing something stupid!

Andy.