### PR TITLE
Expand tests to use irc-parser-test lib, add new mask match util

### DIFF
--- a/irclib/parser.py
+++ b/irclib/parser.py
@@ -23,7 +23,7 @@ TRAIL_SENTINEL = ':'
 CAP_SEP = ' '
 CAP_VALUE_SEP = '='
 
-PREFIX_RE = re.compile(r'^:?(?P<nick>.+?)(?:!(?P<user>.+?))?(?:@(?P<host>.+?))?$')
+PREFIX_RE = re.compile(r'^:?(?P<nick>.*?)(?:!(?P<user>.*?))?(?:@(?P<host>.*?))?$')
 
 TAG_VALUE_ESCAPES = {
     '\\s': ' ',

--- a/irclib/parser.py
+++ b/irclib/parser.py
@@ -522,9 +522,10 @@ class Message(Parseable):
         prefix_str = '' if self.prefix is None else PREFIX_SENTINEL + str(self.prefix)
 
         return PARAM_SEP.join(
-            map(str, filter(None, (
+            str(s) for s in (
                 tag_str, prefix_str, self.command, self.parameters
-            )))
+            )
+            if s
         )
 
     def __bool__(self):

--- a/irclib/parser.py
+++ b/irclib/parser.py
@@ -287,6 +287,12 @@ class TagList(Parseable, dict):
             map(MessageTag.parse, filter(None, text.split(TAGS_SEP)))
         )
 
+    @staticmethod
+    def from_dict(tags):
+        return TagList(
+            MessageTag(k, v) for k, v in tags.items()
+        )
+
 
 class Prefix(Parseable):
     """
@@ -464,6 +470,8 @@ class Message(Parseable):
     def __init__(self, tags, prefix, command, *parameters):
         if isinstance(tags, TagList):
             self._tags = tags
+        elif isinstance(tags, dict):
+            self._tags = TagList.from_dict(tags)
         elif isinstance(tags, str):
             self._tags = TagList.parse(tags)
         elif tags is None:

--- a/irclib/parser.py
+++ b/irclib/parser.py
@@ -255,7 +255,7 @@ class TagList(Parseable, dict):
         super().__init__((tag.name, tag) for tag in tags)
 
     def __str__(self):
-        return TAGS_SENTINEL + TAGS_SEP.join(map(str, self.values()))
+        return TAGS_SEP.join(map(str, self.values()))
 
     def __eq__(self, other):
         if isinstance(other, str):
@@ -336,7 +336,7 @@ class Prefix(Parseable):
         return iter(self._data)
 
     def __str__(self):
-        return PREFIX_SENTINEL + self.mask
+        return self.mask
 
     def __bool__(self):
         return bool(self.nick)
@@ -510,7 +510,14 @@ class Message(Parseable):
         return iter((self.tags, self.prefix, self.command, self.parameters))
 
     def __str__(self):
-        return PARAM_SEP.join(map(str, filter(None, self)))
+        tag_str = '' if self.tags is None else '@' + str(self.tags)
+        prefix_str = '' if self.prefix is None else ':' + str(self.prefix)
+
+        return PARAM_SEP.join(
+            map(str, filter(None, (
+                tag_str, prefix_str, self.command, self.parameters
+            )))
+        )
 
     def __bool__(self):
         return any(self)

--- a/irclib/parser.py
+++ b/irclib/parser.py
@@ -430,9 +430,9 @@ class ParamList(Parseable, list):
             return ParamList()
 
         args = list(data[:-1])
-        if data[-1].startswith(':'):
+        if data[-1].startswith(':') or not data[-1]:
             has_trail = True
-            args.append(data[-1][1:])
+            args.append(data[-1])
         else:
             has_trail = False
             args.append(data[-1])

--- a/irclib/parser.py
+++ b/irclib/parser.py
@@ -294,9 +294,9 @@ class Prefix(Parseable):
     """
 
     def __init__(self, nick, user=None, host=None):
-        self._nick = nick
-        self._user = user
-        self._host = host
+        self._nick = nick or ''
+        self._user = user or ''
+        self._host = host or ''
 
     @property
     def nick(self):

--- a/irclib/parser.py
+++ b/irclib/parser.py
@@ -402,7 +402,7 @@ class ParamList(Parseable, list):
             return ''
 
         if self.has_trail or PARAM_SEP in self[-1]:
-            return PARAM_SEP.join(self[:-1] + [':' + self[-1]])
+            return PARAM_SEP.join(self[:-1] + [TRAIL_SENTINEL + self[-1]])
 
         return PARAM_SEP.join(self)
 
@@ -430,7 +430,7 @@ class ParamList(Parseable, list):
             return ParamList()
 
         args = list(data[:-1])
-        if data[-1].startswith(':') or not data[-1]:
+        if data[-1].startswith(TRAIL_SENTINEL) or not data[-1]:
             has_trail = True
             args.append(data[-1])
         else:
@@ -518,8 +518,8 @@ class Message(Parseable):
         return iter((self.tags, self.prefix, self.command, self.parameters))
 
     def __str__(self):
-        tag_str = '' if self.tags is None else '@' + str(self.tags)
-        prefix_str = '' if self.prefix is None else ':' + str(self.prefix)
+        tag_str = '' if self.tags is None else TAGS_SENTINEL + str(self.tags)
+        prefix_str = '' if self.prefix is None else PREFIX_SENTINEL + str(self.prefix)
 
         return PARAM_SEP.join(
             map(str, filter(None, (

--- a/irclib/util/compare.py
+++ b/irclib/util/compare.py
@@ -1,0 +1,20 @@
+import re
+
+__all__ = ('match_mask',)
+
+GLOB_MAP = {
+    '?': '.',
+    '*': '.*',
+}
+
+
+def match_mask(mask, pattern):
+    """
+    Match hostmask patterns in the standard banmask syntax (eg '*!*@host')
+    """
+    re_pattern = ''
+    for c in pattern:
+        re_pattern += GLOB_MAP.get(c, re.escape(c))
+
+    regex = re.compile('^{}$'.format(re_pattern))
+    return bool(regex.match(mask))

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pytest-cov
 pytest-pep8
 flake8
 python-coveralls
+irc-parser-tests

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -129,3 +129,15 @@ def test_msg_split(data):
 
     # Make sure we handled everything
     assert not atoms
+
+
+@pytest.mark.parametrize('data', parser_tests.data.userhost_split['tests'])
+def test_userhost_split(data):
+    source = Prefix.parse(data['source'])
+    atoms = data['atoms'].copy()
+
+    assert source.nick == atoms.pop('nick', '')
+    assert source.user == atoms.pop('user', '')
+    assert source.host == atoms.pop('host', '')
+
+    assert not atoms

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -1,8 +1,6 @@
 import parser_tests.data
 import pytest
-from pytest import raises
 
-from irclib.errors import ParseError
 from irclib.parser import Message, CapList, Cap, MessageTag, TagList, Prefix, ParamList
 from irclib.string import String, ASCII
 

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -120,12 +120,13 @@ def test_msg_split(data):
 
     assert tags_dict == atoms.pop('tags', None)
 
-    assert msg.prefix == atoms.pop('source', None)
+    prefix = None if msg.prefix is None else str(msg.prefix)
+    assert prefix == atoms.pop('source', None)
 
     # Commands are case-insensitive
     assert String(msg.command, ASCII) == atoms.pop('verb', None)
 
-    assert msg.parameters == atoms.pop('params', [])
+    assert list(msg.parameters) == atoms.pop('params', [])
 
     # Make sure we handled everything
     assert not atoms
@@ -141,3 +142,23 @@ def test_userhost_split(data):
     assert source.host == atoms.pop('host', '')
 
     assert not atoms
+
+
+@pytest.mark.parametrize('data', parser_tests.data.msg_join['tests'])
+def test_msg_join(data):
+    atoms = data['atoms']
+    msg = Message(
+        atoms.pop('tags', None),
+        atoms.pop('source', None),
+        atoms.pop('verb', None),
+        atoms.pop('params', []),
+    )
+
+    assert not atoms, "Not all atoms were handled"
+
+    matches = data['matches']
+    if len(matches) > 1:
+        assert any(str(msg) == match for match in data['matches'])
+    else:
+        # With single matches, make it easier to debug
+        assert str(msg) == matches[0]

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -62,16 +62,13 @@ class TestCaps:
 def test_message_tags():
     cases = (
         ("a=b", "a", "b"),
-        ("test/blah=", "test/blah", None),
+        ("test/blah=", "test/blah", ''),
         ("blah=aa\\r\\n\\:\\\\", "blah", "aa\r\n;\\"),
     )
     for text, name, value in cases:
         tag = MessageTag.parse(text)
         assert tag.name == name
         assert tag.value == value
-
-    with raises(ParseError):
-        MessageTag.parse("key=value\\")
 
 
 def test_trail():

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -1,0 +1,15 @@
+import parser_tests.data
+import pytest
+
+from irclib.util.compare import match_mask
+
+
+@pytest.mark.parametrize('data', parser_tests.data.mask_match['tests'])
+def test_mask_match(data):
+    pattern = data['mask']
+
+    for hostmask in data['matches']:
+        assert match_mask(hostmask, pattern)
+
+    for hostmask in data['fails']:
+        assert not match_mask(hostmask, pattern)


### PR DESCRIPTION
- Add tests from irc-parser-test lib
- Add mask matcher to match the tests from the lib
- Update the parsing logic to match the new tests