### PR TITLE
Fix deprecationwarning for collections.abc

### DIFF
--- a/irclib/util/numerics.py
+++ b/irclib/util/numerics.py
@@ -1,4 +1,5 @@
-from collections import namedtuple, Mapping
+from collections import namedtuple
+from collections.abc import Mapping
 
 __all__ = ('Numeric', 'numerics')
 


### PR DESCRIPTION
Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.9 it will stop working