### PR TITLE
feat: drop python 3.8 support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/devcontainers/python:3.8@sha256:13822a0e211e5b99816ce3f44f064ee385f7679eb407f901f19ed5328ad557d0
+FROM mcr.microsoft.com/devcontainers/python:3.12@sha256:7876580dc67fd460fd962f004cbeb480027e9bbc0657096f1087db11f9eaff39
 
 RUN \
     pipx uninstall mypy \

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -46,4 +46,4 @@ jobs:
         SKIP: nitpick
 
     - name: Run tests
-      run: hatch test --python ${{ matrix.python-version }} --cover --randomize --parallel --retries 2 --retry-delay 1
+      run: hatch test --python ${{ matrix.python-version }} --cover --randomize --retries 2 --retry-delay 1

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -21,7 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - '3.8'
           - '3.9'
           - '3.10'
           - '3.11'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
     hooks:
       - id: pyupgrade
         args:
-          - --py38-plus
+          - --py39-plus
   - repo: https://github.com/MarcoGorelli/auto-walrus
     rev: 7855759486496a3248e9ff37dce7c6d57d39bfce
     hooks:

--- a/irclib/parser.py
+++ b/irclib/parser.py
@@ -5,15 +5,13 @@ Backported from async-irc (https://github.com/snoonetIRC/async-irc.git)
 
 import re
 from abc import ABCMeta, abstractmethod
+from collections.abc import Iterable, Iterator, Sequence
 from typing import (
     Dict,
     Final,
-    Iterable,
-    Iterator,
     List,
     Literal,
     Optional,
-    Sequence,
     Tuple,
     TypeVar,
     Union,
@@ -35,7 +33,7 @@ __all__ = (
 )
 MsgTagList: TypeAlias = Optional["TagList"]
 MsgPrefix: TypeAlias = Optional["Prefix"]
-MessageTuple: TypeAlias = Tuple[MsgTagList, MsgPrefix, str, "ParamList"]
+MessageTuple: TypeAlias = tuple[MsgTagList, MsgPrefix, str, "ParamList"]
 
 TAGS_SENTINEL: Final = "@"
 TAGS_SEP: Final = ";"
@@ -107,7 +105,7 @@ class Cap(Parseable):
         """CAP value."""
         return self._value
 
-    def as_tuple(self) -> Tuple[str, Optional[str]]:
+    def as_tuple(self) -> tuple[str, Optional[str]]:
         """Get data as a tuple of values."""
         return self.name, self.value
 
@@ -145,7 +143,7 @@ class Cap(Parseable):
         return self.name
 
 
-class CapList(Parseable, List[Cap]):
+class CapList(Parseable, list[Cap]):
     """Represents a list of CAP entities."""
 
     @classmethod
@@ -294,7 +292,7 @@ class MessageTag(Parseable):
         return self.name
 
 
-class TagList(Parseable, Dict[str, MessageTag]):
+class TagList(Parseable, dict[str, MessageTag]):
     """Object representing the list of message tags on a line."""
 
     def __init__(self, tags: Iterable[MessageTag] = ()) -> None:
@@ -309,7 +307,7 @@ class TagList(Parseable, Dict[str, MessageTag]):
     def _cmp_type_map(
         obj: object,
     ) -> Union[
-        Tuple[dict[str, MessageTag], Literal[True]], Tuple[None, Literal[False]]
+        tuple[dict[str, MessageTag], Literal[True]], tuple[None, Literal[False]]
     ]:
         if isinstance(obj, str):
             return TagList.parse(obj), True
@@ -338,7 +336,7 @@ class TagList(Parseable, Dict[str, MessageTag]):
         return cls(map(MessageTag.parse, filter(None, text.split(TAGS_SEP))))
 
     @classmethod
-    def from_dict(cls, tags: Dict[str, str]) -> Self:
+    def from_dict(cls, tags: dict[str, str]) -> Self:
         """Create a TagList from a dict of tags."""
         return cls(MessageTag(k, v) for k, v in tags.items())
 
@@ -410,7 +408,7 @@ class Prefix(Parseable):
         return mask
 
     @property
-    def _data(self) -> Tuple[str, str, str]:
+    def _data(self) -> tuple[str, str, str]:
         return self.nick, self.user, self.host
 
     @classmethod
@@ -468,7 +466,7 @@ class Prefix(Parseable):
         return self.mask
 
 
-class ParamList(Parseable, List[str]):
+class ParamList(Parseable, list[str]):
     """An object representing the parameter list from a line."""
 
     def __init__(self, *params: str, has_trail: bool = False) -> None:
@@ -559,13 +557,13 @@ class ParamList(Parseable, List[str]):
 
 
 def _parse_tags(
-    tags: Union[TagList, Dict[str, str], str, None, List[str]],
+    tags: Union[TagList, dict[str, str], str, None, list[str]],
 ) -> MsgTagList:
     if isinstance(tags, TagList):
         return tags
 
     if isinstance(tags, dict):
-        return TagList.from_dict(cast(Dict[str, str], tags))
+        return TagList.from_dict(cast(dict[str, str], tags))
 
     if isinstance(tags, str):
         return TagList.parse(tags)
@@ -590,7 +588,7 @@ def _parse_prefix(prefix: Union[Prefix, str, None, Iterable[str]]) -> MsgPrefix:
 
 
 def _parse_params(
-    parameters: Tuple[Union[str, List[str], ParamList], ...],
+    parameters: tuple[Union[str, list[str], ParamList], ...],
 ) -> ParamList:
     if len(parameters) == 1 and not isinstance(parameters[0], str):
         # This seems to be a list
@@ -599,7 +597,7 @@ def _parse_params(
 
         return ParamList.from_list(parameters[0])
 
-    return ParamList.from_list(cast(Tuple[str, ...], parameters))
+    return ParamList.from_list(cast(tuple[str, ...], parameters))
 
 
 class Message(Parseable):
@@ -607,10 +605,10 @@ class Message(Parseable):
 
     def __init__(
         self,
-        tags: Union[TagList, Dict[str, str], str, None, List[str]],
+        tags: Union[TagList, dict[str, str], str, None, list[str]],
         prefix: Union[str, Prefix, None, Iterable[str]],
         command: str,
-        *parameters: Union[str, List[str], ParamList],
+        *parameters: Union[str, list[str], ParamList],
     ) -> None:
         """Construct message object."""
         self._tags = _parse_tags(tags)

--- a/irclib/util/__init__.py
+++ b/irclib/util/__init__.py
@@ -1,3 +1,5 @@
 """IRC utils."""
 
+from irclib.util import commands, compare, frozendict, numerics, string
+
 __all__ = ("commands", "compare", "frozendict", "numerics", "string")

--- a/irclib/util/commands.py
+++ b/irclib/util/commands.py
@@ -1,6 +1,7 @@
 """IRC command data and utilities."""
 
-from typing import Iterator, List, Mapping, Optional, cast
+from collections.abc import Iterator, Mapping
+from typing import List, Optional, cast
 
 import attr
 
@@ -44,7 +45,7 @@ class Command:
     """A single IRC command."""
 
     name: str
-    args: List[CommandArgument]
+    args: list[CommandArgument]
     min_args: int = 0
     max_args: Optional[int] = None
 

--- a/irclib/util/frozendict.py
+++ b/irclib/util/frozendict.py
@@ -1,15 +1,7 @@
 """Frozen Dict."""
 
-from typing import (
-    Dict,
-    Iterable,
-    Iterator,
-    Mapping,
-    Optional,
-    Tuple,
-    TypeVar,
-    Union,
-)
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Dict, Optional, Tuple, TypeVar, Union
 
 from typing_extensions import Self
 
@@ -28,13 +20,13 @@ class FrozenDict(Mapping[str, _V]):
 
     def __init__(
         self,
-        seq: Union[Mapping[str, _V], Iterable[Tuple[str, _V]], None] = None,
+        seq: Union[Mapping[str, _V], Iterable[tuple[str, _V]], None] = None,
         **kwargs: _V,
     ) -> None:
         """Construct a FrozenDict."""
         d = dict(seq, **kwargs) if seq is not None else dict(**kwargs)
 
-        self.__data: Dict[str, _V] = d
+        self.__data: dict[str, _V] = d
         self.__hash: Optional[int] = None
 
     def copy(self, **kwargs: _V) -> Self:

--- a/irclib/util/numerics.py
+++ b/irclib/util/numerics.py
@@ -1,7 +1,7 @@
 """IRC numeric mapping."""
 
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
-from typing import Iterator, Mapping
 
 __all__ = ("Numeric", "numerics")
 

--- a/irclib/util/string.py
+++ b/irclib/util/string.py
@@ -7,6 +7,7 @@ from typing import (
     Dict,
     Final,
     List,
+    Literal,
     NamedTuple,
     Optional,
     Protocol,
@@ -75,14 +76,14 @@ class String(str):
 
     def __internal_cmp(
         self, other: object, cmp: Callable[[str, str], bool]
-    ) -> bool:
+    ) -> Union[Tuple[bool, Literal[True]], Tuple[None, Literal[False]]]:
         if isinstance(other, String):
-            return cmp(str(self.casefold()), str(other.casefold()))
+            return cmp(str(self.casefold()), str(other.casefold())), True
 
         if isinstance(other, str):
-            return cmp(self, self._wrap(other))
+            return cmp(self, self._wrap(other)), True
 
-        return NotImplemented
+        return None, False
 
     def translate(self, table: TranslateTable) -> "String":
         """Apply translation table to string."""
@@ -305,27 +306,51 @@ class String(str):
 
     def __lt__(self, other: str) -> bool:
         """Compare another string to this one case-insensitively."""
-        return self.__internal_cmp(other, operator.lt)
+        res = self.__internal_cmp(other, operator.lt)
+        if not res[1]:
+            return NotImplemented
+
+        return res[0]
 
     def __le__(self, other: str) -> bool:
         """Compare another string to this one case-insensitively."""
-        return self.__internal_cmp(other, operator.le)
+        res = self.__internal_cmp(other, operator.le)
+        if not res[1]:
+            return NotImplemented
+
+        return res[0]
 
     def __eq__(self, other: object) -> bool:
         """Compare another string to this one case-insensitively."""
-        return self.__internal_cmp(other, operator.eq)
+        res = self.__internal_cmp(other, operator.eq)
+        if not res[1]:
+            return NotImplemented
+
+        return res[0]
 
     def __ne__(self, other: object) -> bool:
         """Compare another string to this one case-insensitively."""
-        return self.__internal_cmp(other, operator.ne)
+        res = self.__internal_cmp(other, operator.ne)
+        if not res[1]:
+            return NotImplemented
+
+        return res[0]
 
     def __gt__(self, other: str) -> bool:
         """Compare another string to this one case-insensitively."""
-        return self.__internal_cmp(other, operator.gt)
+        res = self.__internal_cmp(other, operator.gt)
+        if not res[1]:
+            return NotImplemented
+
+        return res[0]
 
     def __ge__(self, other: str) -> bool:
         """Compare another string to this one case-insensitively."""
-        return self.__internal_cmp(other, operator.ge)
+        res = self.__internal_cmp(other, operator.ge)
+        if not res[1]:
+            return NotImplemented
+
+        return res[0]
 
     def __hash__(self) -> int:
         """Hash the lowercase string."""

--- a/irclib/util/string.py
+++ b/irclib/util/string.py
@@ -29,12 +29,12 @@ class Casemap(NamedTuple):
     upper: str
 
     @property
-    def lower_table(self) -> Dict[int, int]:
+    def lower_table(self) -> dict[int, int]:
         """The lower->upper translation table."""
         return str.maketrans(self.lower, self.upper)
 
     @property
-    def upper_table(self) -> Dict[int, int]:
+    def upper_table(self) -> dict[int, int]:
         """The upper->lower table."""
         return str.maketrans(self.upper, self.lower)
 
@@ -76,7 +76,7 @@ class String(str):
 
     def __internal_cmp(
         self, other: object, cmp: Callable[[str, str], bool]
-    ) -> Union[Tuple[bool, Literal[True]], Tuple[None, Literal[False]]]:
+    ) -> Union[tuple[bool, Literal[True]], tuple[None, Literal[False]]]:
         if isinstance(other, String):
             return cmp(str(self.casefold()), str(other.casefold())), True
 
@@ -137,12 +137,12 @@ class String(str):
 
     def startswith(
         self,
-        prefix: Union[str, Tuple[str, ...]],
+        prefix: Union[str, tuple[str, ...]],
         start: Optional[SupportsIndex] = None,
         end: Optional[SupportsIndex] = None,
     ) -> bool:
         """Check if string starts with a prefix."""
-        prefix_list: Tuple[str, ...]
+        prefix_list: tuple[str, ...]
         prefix_list = (prefix,) if isinstance(prefix, str) else prefix
 
         mapped_list = tuple(self._wrap(p).casefold() for p in prefix_list)
@@ -151,12 +151,12 @@ class String(str):
 
     def endswith(
         self,
-        suffix: Union[str, Tuple[str, ...]],
+        suffix: Union[str, tuple[str, ...]],
         start: Optional[SupportsIndex] = None,
         end: Optional[SupportsIndex] = None,
     ) -> bool:
         """Check if string ends with a suffix."""
-        suffix_list: Tuple[str, ...]
+        suffix_list: tuple[str, ...]
         suffix_list = (suffix,) if isinstance(suffix, str) else suffix
 
         mapped_list = tuple(self._wrap(p).casefold() for p in suffix_list)
@@ -205,7 +205,7 @@ class String(str):
             self._wrap(sub).casefold(), start, end
         )
 
-    def partition(self, sep: str) -> Tuple["String", "String", "String"]:
+    def partition(self, sep: str) -> tuple["String", "String", "String"]:
         """Partition string on a separator."""
         pos = self.find(sep)
         if pos < 0:
@@ -213,7 +213,7 @@ class String(str):
 
         return self[:pos], self[pos : pos + len(sep)], self[pos + len(sep) :]
 
-    def rpartition(self, sep: str) -> Tuple["String", "String", "String"]:
+    def rpartition(self, sep: str) -> tuple["String", "String", "String"]:
         """Reverse partition a string on a separator."""
         pos = self.rfind(sep)
         if pos < 0:
@@ -274,13 +274,13 @@ class String(str):
 
     def split(
         self, sep: Optional[str] = None, maxsplit: SupportsIndex = -1
-    ) -> List[str]:
+    ) -> list[str]:
         """Not currently implemented."""
         raise NotImplementedError
 
     def rsplit(
         self, sep: Optional[str] = None, maxsplit: SupportsIndex = -1
-    ) -> List[str]:
+    ) -> list[str]:
         """Not currently implemented."""
         raise NotImplementedError
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,9 @@ fix-pre-commit = ["hatch run python3 -m scripts.fix_pre_commit"]
 [tool.hatch.envs.hatch-test]
 default-args = ["tests", "irclib"]
 extra-args = ["-vv"]
-dependencies = [
+extra-dependencies = [
+    "coverage[toml]>=6.5",
+    "pytest>=6.0",
     "irc-parser-tests",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,6 +147,7 @@ namespace_packages = true
 python_version = "3.8"
 warn_unused_configs = true
 strict = true
+strict_bytes = false
 strict_optional = true
 check_untyped_defs = true
 show_error_codes = true
@@ -162,7 +163,6 @@ extra_checks = true
 warn_unreachable = true
 warn_return_any = true
 warn_no_return = true
-incremental = false
 enable_error_code = [
     "redundant-self",
     "redundant-expr",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,14 +8,13 @@ dynamic = ["version"]
 description = "A simple library for working with the IRC protocol"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 authors = [{ name = "linuxdaemon", email = "linuxdaemon.irc@gmail.com" }]
 keywords = ["irc", "irc-parser"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -55,6 +54,10 @@ fix-pre-commit = ["hatch run python3 -m scripts.fix_pre_commit"]
 [tool.hatch.envs.hatch-test]
 default-args = ["tests", "irclib"]
 extra-args = ["-vv"]
+dependencies = [
+    "irc-parser-tests",
+]
+
 [tool.hatch.envs.hatch-test.scripts]
 run = "pytest{env:HATCH_TEST_ARGS:} {args}"
 run-cov = "coverage run -m pytest{env:HATCH_TEST_ARGS:} {args}"
@@ -78,12 +81,12 @@ float_to_top = true
 
 [tool.black]
 line-length = 80
-target-version = ["py38"]
+target-version = ["py39"]
 include = '\.pyi?$'
 
 [tool.ruff]
 line-length = 80
-target-version = 'py38'
+target-version = 'py39'
 
 [tool.ruff.format]
 docstring-code-format = true
@@ -144,7 +147,7 @@ line-length = 120
 
 [tool.mypy]
 namespace_packages = true
-python_version = "3.8"
+python_version = "3.9"
 warn_unused_configs = true
 strict = true
 strict_bytes = false
@@ -201,7 +204,7 @@ update_changelog_on_bump = true
 major_version_zero = true
 
 [tool.nitpick]
-style = ["gh://TotallyNotRobots/nitpick/lib-style-3.8.toml"]
+style = ["gh://TotallyNotRobots/nitpick/lib-style-3.9.toml"]
 
 [tool.check-spdx-header]
 headers = ["2017-present linuxdaemon <linuxdaemon.irc@gmail.com>"]

--- a/tests/commands_test.py
+++ b/tests/commands_test.py
@@ -10,8 +10,8 @@ def test_command_lookup() -> None:
     """Test looking up a command."""
     pm = commands.client_commands["privmsg"]
     assert pm is commands.client_commands["PRIVMSG"]
-    assert pm is commands.client_commands.privmsg
-    assert pm is commands.client_commands.PRIVMSG
+    assert pm is commands.client_commands.privmsg  # type: ignore[attr-defined]
+    assert pm is commands.client_commands.PRIVMSG  # type: ignore[attr-defined]
 
     with pytest.raises(KeyError):
         _ = commands.client_commands["foo"]

--- a/tests/frozendict_test.py
+++ b/tests/frozendict_test.py
@@ -25,7 +25,7 @@ def test_init_literal() -> None:
 
 def test_copy() -> None:
     """Test dict copy."""
-    fd = FrozenDict([("a", 1), ("b", 2)])
+    fd: FrozenDict[int] = FrozenDict([("a", 1), ("b", 2)])
     fd1 = fd.copy()
     assert len(fd1) == 2
     assert fd1["a"] == 1

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -312,12 +312,12 @@ class TestMessageTag:
     @pytest.mark.parametrize(("name", "value"), [("a", None), ("a", "b")])
     def test_eq(self, name: str, value: Optional[str]) -> None:
         """Test equals."""
-        assert MessageTag(name, value) == MessageTag(name, value)
+        assert MessageTag(name, value) == MessageTag(name, value)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(("name", "value"), [("a", None), ("a", "b")])
     def test_ne(self, name: str, value: Optional[str]) -> None:
         """Test not-equals."""
-        b = MessageTag(name, value) != MessageTag(name, value)
+        b = MessageTag(name, value) != MessageTag(name, value)  # type: ignore[arg-type]
         assert not b
 
     @pytest.mark.parametrize(
@@ -326,8 +326,8 @@ class TestMessageTag:
     )
     def test_eq_str(self, name: str, value: Optional[str], text: str) -> None:
         """Test equals string."""
-        assert MessageTag(name, value) == text
-        assert text == MessageTag(name, value)
+        assert MessageTag(name, value) == text  # type: ignore[arg-type]
+        assert text == MessageTag(name, value)  # type: ignore[arg-type]
 
     @pytest.mark.parametrize(
         ("name", "value", "text"),
@@ -335,9 +335,9 @@ class TestMessageTag:
     )
     def test_ne_str(self, name: str, value: Optional[str], text: str) -> None:
         """Test not-equals string."""
-        b = MessageTag(name, value) != text
+        b = MessageTag(name, value) != text  # type: ignore[arg-type]
         assert not b
-        b1 = text != MessageTag(name, value)
+        b1 = text != MessageTag(name, value)  # type: ignore[arg-type]
         assert not b1
 
     @pytest.mark.parametrize(
@@ -732,12 +732,12 @@ class TestMessage:
     @pytest.mark.parametrize(
         ("obj", "text"),
         [
-            (Message(None, None, None), ""),
-            (Message(None, None, None, None), ""),
-            (Message(None, None, None, []), ""),
+            (Message(None, None, None), ""),  # type: ignore[arg-type]
+            (Message(None, None, None, None), ""),  # type: ignore[arg-type]
+            (Message(None, None, None, []), ""),  # type: ignore[arg-type]
             (Message(None, None, "COMMAND"), "COMMAND"),
             (Message(["a=b"], None, "COMMAND"), "@a=b COMMAND"),
-            (Message([MessageTag("a", "b")], None, "COMMAND"), "@a=b COMMAND"),
+            (Message([MessageTag("a", "b")], None, "COMMAND"), "@a=b COMMAND"),  # type: ignore[list-item]
             (Message({"a": "b"}, None, "COMMAND"), "@a=b COMMAND"),
             (Message({"a": "b"}, "nick", "COMMAND"), "@a=b :nick COMMAND"),
             (Message(None, ("nick",), "COMMAND"), ":nick COMMAND"),
@@ -813,7 +813,7 @@ class TestMessage:
     @pytest.mark.parametrize(
         "obj",
         [
-            Message(None, None, None),
+            Message(None, None, None),  # type: ignore[arg-type]
             Message(None, None, ""),
             Message(None, "", ""),
             Message("", "", ""),
@@ -861,8 +861,8 @@ def test_trail() -> None:
 )
 def test_comparisons(parse_type: Type[Parseable], text: str) -> None:
     """Test comparing parsed objects to strings."""
-    assert text == parse_type.parse(text)
-    assert not text != parse_type.parse(text)
+    assert text == parse_type.parse(text)  # type: ignore[comparison-overlap]
+    assert not text != parse_type.parse(text)  # type: ignore[comparison-overlap]
 
 
 @pytest.mark.parametrize("data", parser_tests.data.msg_split["tests"])
@@ -912,7 +912,7 @@ def test_msg_join(data: MsgJoinCase) -> None:
     msg = Message(
         atoms.get("tags", None),
         atoms.get("source", None),
-        atoms.get("verb", None),
+        atoms.get("verb", None),  # type: ignore[arg-type]
         atoms.get("params", []),
     )
 

--- a/tests/parser_test.py
+++ b/tests/parser_test.py
@@ -21,10 +21,10 @@ from irclib.util.string import ASCII, String
 class MsgAtoms(TypedDict):
     """Message components for test cases."""
 
-    tags: Dict[str, str]
+    tags: dict[str, str]
     source: str
     verb: str
-    params: List[str]
+    params: list[str]
 
 
 class MsgSplitCase(TypedDict):
@@ -53,7 +53,7 @@ class MsgJoinCase(TypedDict):
     """Message construction test case data."""
 
     atoms: MsgAtoms
-    matches: List[str]
+    matches: list[str]
 
 
 def test_line() -> None:
@@ -213,7 +213,7 @@ class TestCapList:
         ],
     )
     def test_parse(
-        self, text: str, expected: Tuple[Tuple[str, Optional[str]], ...]
+        self, text: str, expected: tuple[tuple[str, Optional[str]], ...]
     ) -> None:
         """Test string parsing."""
         parsed = CapList.parse(text)
@@ -223,13 +223,13 @@ class TestCapList:
             assert actual.value == value
 
     @pytest.mark.parametrize("caps", [[], [Cap("a"), Cap("b", "c")]])
-    def test_eq_list(self, caps: List[Cap]) -> None:
+    def test_eq_list(self, caps: list[Cap]) -> None:
         """Test equals list."""
         assert CapList(caps) == caps
         assert caps == CapList(caps)
 
     @pytest.mark.parametrize("caps", [[], [Cap("a"), Cap("b", "c")]])
-    def test_ne_list(self, caps: List[Cap]) -> None:
+    def test_ne_list(self, caps: list[Cap]) -> None:
         """Test not-equals list."""
         b = CapList(caps) != caps
         assert not b
@@ -244,7 +244,7 @@ class TestCapList:
             ([Cap("a"), Cap("b", "c")], "a b=c "),
         ],
     )
-    def test_eq_str(self, caps: List[Cap], text: str) -> None:
+    def test_eq_str(self, caps: list[Cap], text: str) -> None:
         """Test equals strings."""
         assert CapList(caps) == text
         assert text == CapList(caps)
@@ -257,7 +257,7 @@ class TestCapList:
             ([Cap("a"), Cap("b", "c")], "a b=c "),
         ],
     )
-    def test_ne_str(self, caps: List[Cap], text: str) -> None:
+    def test_ne_str(self, caps: list[Cap], text: str) -> None:
         """Test not-equals strings."""
         b = CapList(caps) != text
         assert not b
@@ -367,7 +367,7 @@ class TestTagList:
             (r"a=ab\r\s\n\:\\;b=abc", [("a", "ab\r \n;\\"), ("b", "abc")]),
         ],
     )
-    def test_parse(self, text: str, tags: List[Tuple[str, str]]) -> None:
+    def test_parse(self, text: str, tags: list[tuple[str, str]]) -> None:
         """Test parsing from string."""
         tag_list = TagList.parse(text)
 
@@ -381,14 +381,14 @@ class TestTagList:
     @pytest.mark.parametrize(
         "tags", [[], [MessageTag("a")], [MessageTag("b", "c")]]
     )
-    def test_eq(self, tags: List[MessageTag]) -> None:
+    def test_eq(self, tags: list[MessageTag]) -> None:
         """Test equals."""
         assert TagList(tags) == TagList(tags)
 
     @pytest.mark.parametrize(
         "tags", [[], [MessageTag("a")], [MessageTag("b", "c")]]
     )
-    def test_ne(self, tags: List[MessageTag]) -> None:
+    def test_ne(self, tags: list[MessageTag]) -> None:
         """Test not-equals."""
         b = TagList(tags) != TagList(tags)
         assert not b
@@ -396,7 +396,7 @@ class TestTagList:
     @pytest.mark.parametrize(
         "tags", [[], [MessageTag("a")], [MessageTag("b", "c")]]
     )
-    def test_eq_list(self, tags: List[MessageTag]) -> None:
+    def test_eq_list(self, tags: list[MessageTag]) -> None:
         """Test equals list."""
         assert TagList(tags) == tags
         assert tags == TagList(tags)
@@ -404,7 +404,7 @@ class TestTagList:
     @pytest.mark.parametrize(
         "tags", [[], [MessageTag("a")], [MessageTag("b", "c")]]
     )
-    def test_ne_list(self, tags: List[MessageTag]) -> None:
+    def test_ne_list(self, tags: list[MessageTag]) -> None:
         """Test not-equals list."""
         b = TagList(tags) != tags
         assert not b
@@ -420,7 +420,7 @@ class TestTagList:
         ],
     )
     def test_eq_dict(
-        self, obj: TagList, other: Dict[str, Optional[str]]
+        self, obj: TagList, other: dict[str, Optional[str]]
     ) -> None:
         """Test equals dict."""
         assert obj == other
@@ -435,7 +435,7 @@ class TestTagList:
         ],
     )
     def test_ne_dict(
-        self, obj: TagList, other: Dict[str, Optional[str]]
+        self, obj: TagList, other: dict[str, Optional[str]]
     ) -> None:
         """Test not-equals dict."""
         b = obj != other
@@ -447,7 +447,7 @@ class TestTagList:
         ("tags", "text"),
         [([], ""), ([MessageTag("a")], "a"), ([MessageTag("b", "c")], "b=c")],
     )
-    def test_eq_str(self, tags: List[MessageTag], text: str) -> None:
+    def test_eq_str(self, tags: list[MessageTag], text: str) -> None:
         """Test equals strings."""
         assert TagList(tags) == text
         assert text == TagList(tags)
@@ -456,7 +456,7 @@ class TestTagList:
         ("tags", "text"),
         [([], ""), ([MessageTag("a")], "a"), ([MessageTag("b", "c")], "b=c")],
     )
-    def test_ne_str(self, tags: List[MessageTag], text: str) -> None:
+    def test_ne_str(self, tags: list[MessageTag], text: str) -> None:
         """Test not-equals strings."""
         b = TagList(tags) != text
         assert not b
@@ -681,7 +681,7 @@ class TestParamList:
         "params",
         [[], [""], ["a"], ["a", "b"], ["a", ":b"], ["a", "b "], ["a", ""]],
     )
-    def test_eq(self, params: List[str]) -> None:
+    def test_eq(self, params: list[str]) -> None:
         """Test equals."""
         assert ParamList(*params) == ParamList(*params)
         assert ParamList(*params) == ParamList.from_list(params)
@@ -691,7 +691,7 @@ class TestParamList:
         "params",
         [[], [""], ["a"], ["a", "b"], ["a", ":b"], ["a", "b "], ["a", ""]],
     )
-    def test_ne(self, params: List[str]) -> None:
+    def test_ne(self, params: list[str]) -> None:
         """Test not-equals."""
         b = ParamList(*params) != ParamList(*params)
         assert not b
@@ -765,7 +765,7 @@ class TestMessage:
         tags: Optional[str],
         prefix: Optional[str],
         command: str,
-        params: List[str],
+        params: list[str],
     ) -> None:
         """Test equals."""
         assert Message(tags, prefix, command, params) == Message(
@@ -781,7 +781,7 @@ class TestMessage:
         tags: Optional[str],
         prefix: Optional[str],
         command: str,
-        params: List[str],
+        params: list[str],
     ) -> None:
         """Test not-equals."""
         b = Message(tags, prefix, command, params) != Message(
@@ -859,7 +859,7 @@ def test_trail() -> None:
         (Message, "command"),
     ],
 )
-def test_comparisons(parse_type: Type[Parseable], text: str) -> None:
+def test_comparisons(parse_type: type[Parseable], text: str) -> None:
     """Test comparing parsed objects to strings."""
     assert text == parse_type.parse(text)  # type: ignore[comparison-overlap]
     assert not text != parse_type.parse(text)  # type: ignore[comparison-overlap]

--- a/tests/string_test.py
+++ b/tests/string_test.py
@@ -143,7 +143,7 @@ def test_contains() -> None:
     """Test `in` operator."""
     assert "a" in String("abc")
     assert String("a") in String("abc")
-    assert 445 not in String("abc")
+    assert 445 not in String("abc")  # type: ignore[comparison-overlap]
 
 
 def test_instance() -> None:

--- a/tests/test_masks.py
+++ b/tests/test_masks.py
@@ -12,8 +12,8 @@ class MaskCase(TypedDict):
     """Mask match test case data."""
 
     mask: str
-    matches: List[str]
-    fails: List[str]
+    matches: list[str]
+    fails: list[str]
 
 
 @pytest.mark.parametrize("data", parser_tests.data.mask_match["tests"])


### PR DESCRIPTION
Python 3.8 is EOL, drop support and update minimum versions for linters and tests to 3.9

BREAKING CHANGE: